### PR TITLE
execfile workaround for python 3

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -419,7 +419,9 @@ import os
 import_script = os.path.expanduser("~/.vaex/vaex_import.py")
 if os.path.exists(import_script):
 	try:
-		execfile(import_script)
+		with open(import_script) as f:
+			code = compile(f.read(), import_script, 'exec')
+			exec(code)
 	except:
 		import traceback
 		traceback.print_tb()


### PR DESCRIPTION
The `~/.vaex/vaex_import.py` script doesn't work in python 3, because `execfile` is gone. This replaces it with something that will work in either 2 or 3.