### PR TITLE
make vaex-core only depend on futures for python 2

### DIFF
--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -15,8 +15,10 @@ url         = 'https://www.github.com/maartenbreddels/vaex'
 # TODO: can we do without requests and progressbar2?
 # TODO: after python2 supports frops, future and futures can also be dropped
 # TODO: would be nice to have astropy only as dep in vaex-astro
-install_requires_core = ["numpy>=1.11", "astropy>=2", "aplus", "futures>=2.2.0",
+install_requires_core = ["numpy>=1.11", "astropy>=2", "aplus",
     "future>=0.15.2", "pyyaml", "progressbar2", "psutil>=1.2.1", "requests", "six", "cloudpickle"]
+if sys.version_info[0] == 2:
+    install_requires_core.append("futures>=2.2.0")
 install_requires_viz = ["matplotlib>=1.3.1", ]
 install_requires_astro = ["kapteyn"]
 


### PR DESCRIPTION
See discussion in https://github.com/conda-forge/staged-recipes/pull/4627.
  