### PR TITLE
don't auto-add hdf5 extension

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -113,7 +113,7 @@ def _convert_name(filenames, shuffle=False):
     if len(filenames) > 1:
         return base + "_and_{}_more.hdf5".format(len(filenames)-1)
     else:
-        return base + ".hdf5"
+        return base
 
 
 def open(path, convert=False, shuffle=False, *args, **kwargs):


### PR DESCRIPTION
This fixes an error occurring in the following way when opening files Snapshot.049-{0..9}.hdf5:
```python
In [1]: import vaex
In [2]: ds = vaex.open('Snapshot.049-?.hdf5')
ERROR:MainThread:vaex:error opening 'Snapshot.049-3.hdf5.hdf5'
ERROR:MainThread:vaex:error opening 'Snapshot.049-?.hdf5'
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
<ipython-input-2-6d4d312308b7> in <module>()
----> 1 ds = vaex.open('Snapshot.049-?.hdf5')

~/Env/Amuse/lib/python3.6/site-packages/vaex/__init__.py in open(path, convert, shuffle, *args, **kwargs)
    194                     for filename in filenames:
    195                         open(filename, convert=convert is not False, shuffle=shuffle, **kwargs)
--> 196                     ds = open_many([_convert_name(k, shuffle=shuffle) for k in filenames])
    197                 if convert:
    198                     ds.export_hdf5(filename_hdf5, shuffle=shuffle)

~/Env/Amuse/lib/python3.6/site-packages/vaex/__init__.py in open_many(filenames)
    219         print(filename)
    220         if filename and filename[0] != "#":
--> 221             datasets.append(open(filename))
    222     return vaex.dataset.DatasetConcatenated(datasets=datasets)
    223 

~/Env/Amuse/lib/python3.6/site-packages/vaex/__init__.py in open(path, convert, shuffle, *args, **kwargs)
    161             ds = None
    162             if len(filenames) == 0:
--> 163                 raise IOError('Could not open file: {}, it does not exists'.format(path))
    164             filename_hdf5 = _convert_name(filenames, shuffle=shuffle)
    165             filename_hdf5_noshuffle = _convert_name(filenames, shuffle=False)

OSError: Could not open file: Snapshot.049-3.hdf5.hdf5, it does not exists

In [3]: ds = vaex.open('Snapshot.049-?')
ERROR:MainThread:vaex:error opening 'Snapshot.049-?'
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
<ipython-input-3-aadfbc5d5be4> in <module>()
----> 1 ds = vaex.open('Snapshot.049-?')

~/Env/Amuse/lib/python3.6/site-packages/vaex/__init__.py in open(path, convert, shuffle, *args, **kwargs)
    161             ds = None
    162             if len(filenames) == 0:
--> 163                 raise IOError('Could not open file: {}, it does not exists'.format(path))
    164             filename_hdf5 = _convert_name(filenames, shuffle=shuffle)
    165             filename_hdf5_noshuffle = _convert_name(filenames, shuffle=False)

OSError: Could not open file: Snapshot.049-?, it does not exists
```