### PR TITLE
fix: preserve order columns in getattr/copy and allow expressions

### DIFF
--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -3956,6 +3956,7 @@ array([[ 53.54521742,  -3.8123135 ,  -0.98260511],
 
         name = vaex.utils.find_valid_name(name, used=[] if not unique else self.get_column_names())
         self.virtual_columns[name] = expression
+        self.column_names.append(name)
         self._save_assign_expression(name)
         self.signal_column_changed.emit(self, name, "add")
         # self.write_virtual_meta()
@@ -4204,20 +4205,21 @@ array([[ 53.54521742,  -3.8123135 ,  -0.98260511],
     def get_column_names(self, virtual=True, strings=True, hidden=False):
         """Return a list of column names
 
-
         :param virtual: If False, skip virtual columns
         :param hidden: If False, skip hidden columns
         :param strings: If False, skip string columns
         :rtype: list of str
         """
-        names = [name for name in self.column_names if strings or (self.dtype(name).type != np.string_)]
-        if virtual:
-            names += [key for key in self.virtual_columns.keys()]
-        if not hidden:
-            names = [name for name in names if not name.startswith('__')]
-        return names
-        # return list([name for name in self.column_names if (strings or (self.dtype(name).type != np.string_)) and (hidden or not name.startswith("__"))]) \
-        #     + ([key for key in self.virtual_columns.keys() if (hidden or (not key.startswith("__")))] if virtual else [])
+        def column_filter(name):
+            '''Return True if column with specified name should be returned'''
+            if not virtual and name in self.virtual_columns:
+                return False
+            if not strings and self.dtype(name).type == np.string_:
+                return False
+            if not hidden and name.startswith('__'):
+                return False
+            return True
+        return [name for name in self.column_names if column_filter(name)]
 
     def __len__(self):
         """Returns the number of rows in the dataset (filtering applied)"""

--- a/tests/getattr_test.py
+++ b/tests/getattr_test.py
@@ -26,3 +26,19 @@ def test_column_subset_virtual(ds_filtered):
     dss = ds[['m']]
     assert dss.get_column_names() == ['m']
     assert set(dss.get_column_names(hidden=True)) == set(['__x', '__y', 'm'])
+
+def test_column_order(ds_local):
+    ds = ds_local
+    dss = ds[['x', 'y']]
+    assert dss.get_column_names() == ['x', 'y']
+    assert np.array(dss).T.tolist() == [ds.x.values.tolist(), ds.y.values.tolist()]
+
+    dss = ds[['y', 'x']]
+    assert dss.get_column_names() == ['y', 'x']
+    assert np.array(dss).T.tolist() == [ds.y.values.tolist(), ds.x.values.tolist()]
+
+def test_expression(ds_local):
+    ds = ds_local
+    # this will do some name mangling, but we don't care about the names
+    dss = ds[['y/10', 'x/5']]
+    assert np.array(dss).T.tolist() == [(ds.y/10).values.tolist(), (ds.x/5).values.tolist()]

--- a/tests/getattr_test.py
+++ b/tests/getattr_test.py
@@ -37,8 +37,39 @@ def test_column_order(ds_local):
     assert dss.get_column_names() == ['y', 'x']
     assert np.array(dss).T.tolist() == [ds.y.values.tolist(), ds.x.values.tolist()]
 
+def test_column_order_virtual(ds_local):
+    ds = ds_local
+    # this will do some name mangling, but we don't care about the names
+    ds['r'] = ds.y + 10
+    ds = ds_local
+    dss = ds[['x', 'r']]
+    assert dss.get_column_names() == ['x', 'r']
+    assert np.array(dss).T.tolist() == [ds.x.values.tolist(), ds.r.values.tolist()]
+
+    dss = ds[['r', 'x']]
+    assert dss.get_column_names() == ['r', 'x']
+    assert np.array(dss).T.tolist() == [ds.r.values.tolist(), ds.x.values.tolist()]
+
 def test_expression(ds_local):
     ds = ds_local
     # this will do some name mangling, but we don't care about the names
     dss = ds[['y/10', 'x/5']]
+    assert 'y' in dss.get_column_names()[0]
+    assert 'x' in dss.get_column_names()[1]
     assert np.array(dss).T.tolist() == [(ds.y/10).values.tolist(), (ds.x/5).values.tolist()]
+
+
+@pytest.mark.skip(reason="Not implemented yet, should work, might need refactoring of copy")
+def test_expression_virtual(ds_local):
+    ds = ds_local
+    # this will do some name mangling, but we don't care about the names
+    ds['r'] = ds.y + 10
+    dss = ds[['r/10', 'x/5']]
+    assert 'r' in dss.get_column_names()[0]
+    assert 'x' in dss.get_column_names()[1]
+    assert np.array(dss).T.tolist() == [(ds.r/10).values.tolist(), (ds.x/5).values.tolist()]
+
+    dss = ds[['x/5', 'r/10']]
+    assert 'r' in dss.get_column_names()[0]
+    assert 'x' in dss.get_column_names()[1]
+    assert np.array(dss).T.tolist() == [(ds.x/5).values.tolist(), (ds.r/10).values.tolist()]


### PR DESCRIPTION
ds[['y', 'x']] would not preserve the order, causing #123 to fail