### PR TITLE
Fix: serialize: function serialize testing was too strict

### DIFF
--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -465,8 +465,8 @@ class Function(object):
     def __init__(self, dataset, name, f):
         self.dataset = dataset
         self.name = name
-        # if not serializable, assume we can use pickle
-        if not isinstance(f, FunctionSerializable):
+
+        if not vaex.serialize.can_serialize(f): # if not serializable, assume we can use pickle
             f = FunctionSerializablePickle(f)
         self.f = f
 

--- a/packages/vaex-core/vaex/test/dataset.py
+++ b/packages/vaex-core/vaex/test/dataset.py
@@ -38,9 +38,11 @@ def function_upper(x):
 	return np.array(x.decode('ascii').upper())
 import vaex.serialize
 @vaex.serialize.register
-class Multiply(object):
+class Multiply:
 	def __init__(self, scale=0): self.scale = scale
-	def state_set(self, state): self.scale = state
+	@classmethod
+	def state_from(cls, state):
+		return cls(scale=state)
 	def state_get(self): return self.scale
 	def __call__(self, x): return x * self.scale
 

--- a/tests/serialize_test.py
+++ b/tests/serialize_test.py
@@ -1,0 +1,17 @@
+from common import *
+import vaex.serialize
+
+@vaex.serialize.register
+class TestFunc:
+    def state_get(self):
+        return "hi"
+
+def test_serialize_function():
+    ds = vaex.from_scalars(x=1)
+    test_func = TestFunc()
+    ds.add_function('func', test_func)
+    state = ds.state_get()
+    assert 'functions' in state
+    assert 'func' in state['functions']
+    assert 'TestFunc' in state['functions']['func']['cls']
+    assert 'hi' == state['functions']['func']['state']


### PR DESCRIPTION
Wasn't using the registry for serializable function, meaning we would pickle when not needed.