### PR TITLE
added regex to get_columns_names()

### DIFF
--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -5879,3 +5879,4 @@ class DatasetArrays(DatasetLocal):
         If any of the columns contain masked arrays, the masks are ignored (i.e. the masked elements are returned as well).
         """
         return self.__array__()
+    

--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -4228,7 +4228,6 @@ array([[ 53.54521742,  -3.8123135 ,  -0.98260511],
         >>> df.get_column_names(regex='x.*')
         ['x', 'x2']
         """
-
         def column_filter(name):
             '''Return True if column with specified name should be returned'''
             if regex and not re.match(regex, name):
@@ -4239,7 +4238,6 @@ array([[ 53.54521742,  -3.8123135 ,  -0.98260511],
                 return False
             if not hidden and name.startswith('__'):
                 return False
-
             return True
         return [name for name in self.column_names if column_filter(name)]
 
@@ -5879,4 +5877,3 @@ class DatasetArrays(DatasetLocal):
         If any of the columns contain masked arrays, the masks are ignored (i.e. the masked elements are returned as well).
         """
         return self.__array__()
-    

--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -4208,22 +4208,28 @@ array([[ 53.54521742,  -3.8123135 ,  -0.98260511],
         """Returns the number of columns, not counting virtual ones"""
         return len(self.column_names)
 
-    def get_column_names(self, virtual=True, strings=True, hidden=False):
+    def get_column_names(self, virtual=True, strings=True, hidden=False, regex=None):
         """Return a list of column names
 
         :param virtual: If False, skip virtual columns
         :param hidden: If False, skip hidden columns
         :param strings: If False, skip string columns
+        :param regex: If not None, return columns matched with the regular expression and virtual, hidden or strings  as requested
         :rtype: list of str
         """
+
         def column_filter(name):
             '''Return True if column with specified name should be returned'''
+            if regex is not None:
+                if re.compile(r'{}'.format(regex)).match(name) is None:
+                    return False
             if not virtual and name in self.virtual_columns:
                 return False
             if not strings and self.dtype(name).type == np.string_:
                 return False
             if not hidden and name.startswith('__'):
                 return False
+
             return True
         return [name for name in self.column_names if column_filter(name)]
 

--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -4214,15 +4214,25 @@ array([[ 53.54521742,  -3.8123135 ,  -0.98260511],
         :param virtual: If False, skip virtual columns
         :param hidden: If False, skip hidden columns
         :param strings: If False, skip string columns
-        :param regex: If not None, return columns matched with the regular expression and virtual, hidden or strings  as requested
+        :param regex: Only return column names matching the (optional) regular expression
         :rtype: list of str
+
+        Examples:
+        >>> import vaex
+        >>> df = vaex.from_scalars(x=1, x2=2, y=3, s='string')
+        >>> df['r'] = (df.x**2 + df.y**2)**2
+        >>> df.get_column_names()
+        ['x', 'x2', 'y', 's', 'r']
+        >>> df.get_column_names(virtual=False)
+        ['x', 'x2', 'y', 's']
+        >>> df.get_column_names(regex='x.*')
+        ['x', 'x2']
         """
 
         def column_filter(name):
             '''Return True if column with specified name should be returned'''
-            if regex is not None:
-                if re.compile(r'{}'.format(regex)).match(name) is None:
-                    return False
+            if regex and not re.match(regex, name):
+                return False
             if not virtual and name in self.virtual_columns:
                 return False
             if not strings and self.dtype(name).type == np.string_:

--- a/tests/column_names_test.py
+++ b/tests/column_names_test.py
@@ -1,3 +1,4 @@
+import vaex
 from common import *
 
 def test_column_names(ds_local):
@@ -7,3 +8,10 @@ def test_column_names(ds_local):
 	assert columns_names == ds.get_column_names(virtual=True)
 	assert '__x' in ds.get_column_names(virtual=True, hidden=True)
 	assert len(columns_names) == len(ds.get_column_names(virtual=True, hidden=True))-1
+
+	ds = vaex.example()
+	ds['__x'] = ds['x'] + 1
+	assert 'FeH' in ds.get_column_names(regex='e*')
+	assert 'FeH' not in ds.get_column_names(regex='e')
+	assert '__x' not in ds.get_column_names(regex='__x')
+	assert '__x' in ds.get_column_names(regex='__x', hidden=True)


### PR DESCRIPTION
get_columns_namesa now expect regex pattern.
All other argumetns still apply. 


```
ds.get_column_names(regex='e*')
```